### PR TITLE
Fix for PHP 7.2+

### DIFF
--- a/src/fields/ColourSwatches.php
+++ b/src/fields/ColourSwatches.php
@@ -108,7 +108,7 @@ class ColourSwatches extends Field
     {
         Craft::$app->getView()->registerAssetBundle(ColourSwatchesFieldAsset::class);
 
-        if (count($this->options)) {
+        if ($this->options && count($this->options)) {
             $rows = $this->options;
         } elseif ($this->palette) {
             $rows = Plugin::$plugin->settings->palettes[$this->palette];


### PR DESCRIPTION
On PHP 7.2+, calling count() on a null/non-countable type throws an exception:

```
PHP Warning – yii\base\ErrorException
count(): Parameter must be an array or an object that implements Countable

1. in ../vendor/rias/craft-colour-swatches/src/fields/ColourSwatches.php
```

This simple additional check fixes the issue for me.